### PR TITLE
Refactor: partial ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         id: toolchain
         with:
           cond: ${{ matrix.rust == 'msrv' }}
-          if_true: 1.42.0
+          if_true: 1.44.1
           if_false: ${{ matrix.rust }}
 
       - uses: actions-rs/toolchain@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,16 @@ mod tests {
     }
 
     #[test]
+    fn case_insensitive() {
+        assert_eq!(
+            SSHOption::parse("PoRt 22")
+                .expect("parse failed")
+                .expect("expected value"),
+            SSHOption::Port(22)
+        )
+    }
+
+    #[test]
     fn it_works2() {
         assert_eq!(
             SSHOption::parse("port 22")


### PR DESCRIPTION
Strikes a midpoint between 3085471 and using borrows everywhere: let the options themselves own their configuration, but take in references to parse from.

The idea being that we'll make copies as necessary but can avoid allocations for uncommon things like "interior" quotes on a port number or identifier.