### PR TITLE
feat: `getservbyname` when libc is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,21 +37,27 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
+      - name: build
+        uses: actions-rs/cargo@v1
         with:
           command: build
 
-      - uses: actions-rs/cargo@v1
+      - name: test
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '--cfg CI'
         with:
           command: test
           args: --no-default-features --features '${{ matrix.features }}'
 
-      - uses: actions-rs/cargo@v1
+      - name: check fmt
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-      - uses: actions-rs/cargo@v1
+      - name: clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           - beta
           - nightly
           - msrv # Minimum Supported Rust Version, see below
+        features:
+          - ''
+          - with_libc
 
     steps:
       - uses: actions/checkout@v2
@@ -41,6 +44,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --no-default-features --features '${{ matrix.features }}'
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
           - nightly
           - msrv # Minimum Supported Rust Version, see below
         features:
+          - default
           - ''
-          - with_libc
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,15 @@ description = """
 A configuration wrapper for ssh2-rs 
 """
 
+[features]
+default = ["with_libc"]
+
+with_libc = ["libc"]
+
 [dependencies]
 ssh2 = "0.8.1"
 itertools = "0.9.0"
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 #[macro_use]
 extern crate assert_matches;
 
+#[cfg(feature = "with_libc")]
+extern crate libc;
+
 /// Individual SSH config options, e.g. `Port 22` or `Hostname example.com`
 pub mod option;
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -76,11 +76,45 @@ where
 
         match keyword.to_ascii_lowercase().as_str() {
             "user" => args.map_owned(User),
-            "port" => args.map_next(|arg, _| Ok(Port(arg.parse()?))),
+            "port" => args.map_next(|arg, _| Ok(Port(a2port(arg)?))),
             "hostname" => args.map_owned(Hostname),
 
             _ => Err(Error::from(DetailedError::BadOption(keyword.to_string()))),
         }
+    }
+}
+
+#[cfg(not(feature = "with_libc"))]
+fn a2port(s: &str) -> Result<u16, std::num::ParseIntError> {
+    s.parse()
+}
+
+// See: https://github.com/openssh/openssh-portable/blob/e073106f370cdd2679e41f6f55a37b491f0e82fe/misc.c#L414-L432
+#[cfg(feature = "with_libc")]
+fn a2port(s: &str) -> Result<u16, std::num::ParseIntError> {
+    use libc::getservbyname;
+    use std::convert::TryInto;
+    use std::ffi::CString;
+
+    match s.parse() {
+        res @ Ok(_) => res,
+        num_err @ Err(_) => match CString::new(s) {
+            Ok(cstr) => unsafe {
+                let servent = getservbyname(
+                    cstr.as_ptr(),
+                    CString::new("tcp").expect("CString::new failed").as_ptr(),
+                );
+                if servent.is_null() {
+                    num_err
+                } else {
+                    // network byte order is big-endian
+                    Ok(u16::from_be((*servent).s_port.try_into().expect(
+                        "`/etc/services` database entry for port out of range (<0 or >65,536)",
+                    )))
+                }
+            },
+            Err(_) => num_err,
+        },
     }
 }
 
@@ -188,7 +222,6 @@ pub enum DetailedError {
     BadOption(String),
 
     /// InvalidPort occurs when we encounter a port that can't be recognize, e.g. `Port -1`
-    // TODO: getservfromname
     InvalidPort(std::num::ParseIntError),
 }
 
@@ -819,8 +852,9 @@ mod test {
 
         assert_parse!(r#"User dusty"#, SSHOption::User(String::from("dusty")));
         assert_parse!(r#"Port 22"#, SSHOption::Port(22));
-        // TODO: getservbyname
-        // assert_parse!(r#"Port ssh"#, SSHOption::Port(22));
+        if cfg!(feature = "with_libc") {
+            assert_parse!(r#"Port ssh"#, SSHOption::Port(22));
+        }
     }
 }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -100,10 +100,8 @@ fn a2port(s: &str) -> Result<u16, std::num::ParseIntError> {
         res @ Ok(_) => res,
         num_err @ Err(_) => match CString::new(s) {
             Ok(cstr) => unsafe {
-                let servent = getservbyname(
-                    cstr.as_ptr(),
-                    CString::new("tcp").expect("CString::new failed").as_ptr(),
-                );
+                let tcp = CString::new("tcp").expect("CString::new failed");
+                let servent = getservbyname(cstr.as_ptr(), tcp.as_ptr());
                 if servent.is_null() {
                     num_err
                 } else {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -7,6 +7,14 @@ use tempfile::tempdir;
 
 #[test]
 fn hello_world() {
+    assert!(Command::new("ssh")
+        .args(&["-V"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("failed to execute process")
+        .success());
+
     let output = Command::new("ssh")
         .args(&["-T", "-F", "/dev/null", "-G", "example.com"])
         .output()

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -176,7 +176,7 @@ fn leading_zero_width() {
 
 #[test]
 // TODO: Github CI doesn't populate /etc/services
-#[cfg(target_os = "macos")]
+// #[cfg(target_os = "macos")]
 fn hello_world5() {
     let dir = tempdir().unwrap();
     let cfg_file = dir.path().join("hello_world5_config");


### PR DESCRIPTION
To match the behavior of upstream ssh, refer to the getservbyname database when appropriate.